### PR TITLE
feature: Add optional to show schema id instead of def-#

### DIFF
--- a/ref-resolver.js
+++ b/ref-resolver.js
@@ -17,7 +17,8 @@ const kConsumed = Symbol('json-schema-resolver.consumed') // when an external js
 
 const defaultOpts = {
   target: 'draft-07',
-  clone: false
+  clone: false,
+  showSchemaId: false
 }
 
 const targetSupported = ['draft-07'] // TODO , 'draft-08'
@@ -33,7 +34,7 @@ const targetCfg = {
 // logic: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.1
 function jsonSchemaResolver (options) {
   const ee = new EventEmitter()
-  const { clone, target, applicationUri, externalSchemas: rootExternalSchemas } = Object.assign({}, defaultOpts, options)
+  const { clone, target, applicationUri, externalSchemas: rootExternalSchemas, showSchemaId } = Object.assign({}, defaultOpts, options)
 
   const allIds = new Map()
   let rolling = 0
@@ -137,7 +138,7 @@ function jsonSchemaResolver (options) {
     const id = URI.serialize(baseUri) + rel
     if (!allIds.has(id)) {
       debug('Collected $id %s', id)
-      json[kRefToDef] = `def-${rolling++}`
+      json[kRefToDef] = showSchemaId ? id : `def-${rolling++}`
       allIds.set(id, json)
     } else {
       debug('WARN duplicated id %s .. IGNORED - ', id)

--- a/test/ref-resolver.test.js
+++ b/test/ref-resolver.test.js
@@ -245,51 +245,45 @@ test('absolute $ref #2', t => {
   t.equal(out.properties.houses.items.$ref, '#/definitions/def-0')
 })
 
+const phoneNumberSchemaId = {
+  $id: 'phoneNumber',
+  type: 'object',
+  properties: {
+    countryCode: { type: 'string' },
+    number: { type: 'string' }
+  }
+}
+
 test('set showSchemaId to be true with relativeId', t => {
-  t.plan(1)
+  t.plan(4)
 
   const schema = factory('relativeId-showSchemaId')
-  const absSchemaId = {
-    $id: 'relativeIdSchemaId',
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string'
-      }
-    }
-  }
-  const externalSchemas = [absSchemaId]
+  const externalSchemas = [phoneNumberSchemaId]
 
   const resolver = RefResolver({
     clone: true,
     showSchemaId: true
   })
-  resolver.resolve(schema, {
+  const out = resolver.resolve(schema, {
     externalSchemas
   })
   const definitions = resolver.definitions()
 
   t.deepEquals(definitions, {
     definitions: {
-      [absSchemaId.$id]: absSchemaId
+      [phoneNumberSchemaId.$id]: phoneNumberSchemaId
     }
   })
+  t.equal(out.properties.personal.homeNumber.$ref, '#/definitions/phoneNumber')
+  t.equal(out.properties.personal.mobilePhoneNumber.$ref, '#/definitions/phoneNumber')
+  t.equal(out.properties.work.$ref, '#/definitions/phoneNumber')
 })
 
 test('set showSchemaId to be true with absoluteId', t => {
   t.plan(1)
 
   const schema = factory('absoluteId-localRef')
-  const absSchemaId = {
-    $id: 'relativeIdSchemaId',
-    type: 'object',
-    properties: {
-      foo: {
-        type: 'string'
-      }
-    }
-  }
-  const externalSchemas = [absSchemaId]
+  const externalSchemas = [phoneNumberSchemaId]
 
   const resolver = RefResolver({
     clone: true,
@@ -302,7 +296,7 @@ test('set showSchemaId to be true with absoluteId', t => {
 
   t.deepEquals(definitions, {
     definitions: {
-      'http://example.com/relativeIdSchemaId': absSchemaId
+      'http://example.com/phoneNumber': phoneNumberSchemaId
     }
   })
 })

--- a/test/ref-resolver.test.js
+++ b/test/ref-resolver.test.js
@@ -244,3 +244,65 @@ test('absolute $ref #2', t => {
   t.equal(out.properties.address.$ref, '#/definitions/def-0')
   t.equal(out.properties.houses.items.$ref, '#/definitions/def-0')
 })
+
+test('set showSchemaId to be true with relativeId', t => {
+  t.plan(1)
+
+  const schema = factory('relativeId-showSchemaId')
+  const absSchemaId = {
+    $id: 'relativeIdSchemaId',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    }
+  }
+  const externalSchemas = [absSchemaId]
+
+  const resolver = RefResolver({
+    clone: true,
+    showSchemaId: true
+  })
+  resolver.resolve(schema, {
+    externalSchemas
+  })
+  const definitions = resolver.definitions()
+
+  t.deepEquals(definitions, {
+    definitions: {
+      [absSchemaId.$id]: absSchemaId
+    }
+  })
+})
+
+test('set showSchemaId to be true with absoluteId', t => {
+  t.plan(1)
+
+  const schema = factory('absoluteId-localRef')
+  const absSchemaId = {
+    $id: 'relativeIdSchemaId',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    }
+  }
+  const externalSchemas = [absSchemaId]
+
+  const resolver = RefResolver({
+    clone: true,
+    showSchemaId: true
+  })
+  resolver.resolve(schema, {
+    externalSchemas
+  })
+  const definitions = resolver.definitions()
+
+  t.deepEquals(definitions, {
+    definitions: {
+      'http://example.com/relativeIdSchemaId': absSchemaId
+    }
+  })
+})

--- a/test/schemas/relativeId-showSchemaId.js
+++ b/test/schemas/relativeId-showSchemaId.js
@@ -1,8 +1,18 @@
 module.exports = {
-  $id: 'relativeAddressShowSchemaId',
+  $id: 'personPhoneNumbers',
   type: 'object',
   properties: {
-    foo: { type: 'string' },
-    bar: { type: 'string' }
+    personal: {
+      type: 'object',
+      homeNumber: {
+        $ref: '#/definitions/phoneNumber'
+      },
+      mobilePhoneNumber: {
+        $ref: '#/definitions/phoneNumber'
+      }
+    },
+    work: {
+      $ref: '#/definitions/phoneNumber'
+    }
   }
 }

--- a/test/schemas/relativeId-showSchemaId.js
+++ b/test/schemas/relativeId-showSchemaId.js
@@ -1,0 +1,8 @@
+module.exports = {
+  $id: 'relativeAddressShowSchemaId',
+  type: 'object',
+  properties: {
+    foo: { type: 'string' },
+    bar: { type: 'string' }
+  }
+}


### PR DESCRIPTION
This PR will improve a thing that i found on [fastify-swagger](https://github.com/fastify/fastify-swagger) about model section right now it show `def-#` only on schema id, so i added more option to show schema id from `$id` instead.

if defined `$id` of schema as `ResponseErrorObject`, the result should be like:

Actual:
```
"definitions": {
  "def-0": {
    "type": "object",
    "properties": {
      "code": { "type": "string" },
      "message": { "type": "string" }
    }
  }
}
```

Expect:
```
"definitions": {
  "ResponseErrorObject": {
    "type": "object",
    "properties": {
      "code": { "type": "string" },
      "message": { "type": "string" }
    }
  }
}
```