### PR TITLE
fix: do not resolve meta refs

### DIFF
--- a/ref-resolver.js
+++ b/ref-resolver.js
@@ -190,7 +190,7 @@ function jsonSchemaResolver (options) {
    * @param {URI} baseUri
    * @param {*} json
    */
-function mapIds (ee, baseUri, json) {
+function mapIds (ee, baseUri, json, parentKey) {
   if (!(json instanceof Object)) return
 
   if (json.$id) {
@@ -218,10 +218,10 @@ function mapIds (ee, baseUri, json) {
 
   const fields = Object.keys(json)
   for (const prop of fields) {
-    if (prop === '$ref') {
+    if (prop === '$ref' && (typeof json.$ref === 'string') && parentKey !== 'properties') {
       ee.emit('$ref', json, baseUri, json[prop])
     }
-    mapIds(ee, baseUri, json[prop])
+    mapIds(ee, baseUri, json[prop], parentKey)
   }
 }
 

--- a/test/ref-resolver.test.js
+++ b/test/ref-resolver.test.js
@@ -244,3 +244,12 @@ test('absolute $ref #2', t => {
   t.equal(out.properties.address.$ref, '#/definitions/def-0')
   t.equal(out.properties.houses.items.$ref, '#/definitions/def-0')
 })
+
+test('do not resolve meta refs', t => {
+  t.plan(1)
+  const schema = factory('metaRef')
+
+  const resolver = RefResolver({ clone: true })
+  const out = resolver.resolve(schema, {})
+  t.same(out.properties.$ref, { type: 'string' })
+})

--- a/test/schemas/metaRef.js
+++ b/test/schemas/metaRef.js
@@ -1,0 +1,7 @@
+module.exports = {
+  $id: 'schemaWithMetaRef',
+  type: 'object',
+  properties: {
+    $ref: { type: 'string' }
+  }
+}


### PR DESCRIPTION
These changes allow for meta refs to be skipped while resolving a schema which is necessary to conform to https://json-schema.org/draft-07/schema. 

```
{
  $id: 'schemaWithMetaRef',
  type: 'object',
  properties: {
    $ref: { type: 'string' }
  }
}
