### PR TITLE
break: drop uri-js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
     with:
       lint: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # json-schema-resolver
 
-[![CI](https://github.com/Eomm/json-schema-resolver/workflows/ci/badge.svg)](https://github.com/Eomm/json-schema-resolver/actions?query=workflow%3Aci)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+[![CI](https://github.com/Eomm/json-schema-resolver/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Eomm/json-schema-resolver/actions/workflows/ci.yml)
+[![NPM version](https://img.shields.io/npm/v/json-schema-resolver.svg?style=flat)](https://www.npmjs.com/package/json-schema-resolver)
+[![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
 
 Resolve all `$refs` in your [JSON schema](https://json-schema.org/specification.html)!  
 This module will resolve the `$ref` keyword against the `externalSchemas` you will provide.  

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const ref = RefResolver({
   clone: true, // Clone the input schema without changing it. Default: false,
   buildLocalReference (json, baseUri, fragment, i) {
     // the `json` that is being resolved
-    // the `baseUri` object of the schema. Its values is the parse result from https://www.npmjs.com/package/uri-js
+    // the `baseUri` object of the schema. Its values is the parse result from https://www.npmjs.com/package/fast-uri
     // the `fragment` is the `$ref` string when the `$ref` is a relative reference
     // the `i` is a local counter to generate a unique key
     return `def-${i}` // default value

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = require('neostandard')({
+  ignores: require('neostandard').resolveIgnoresFromGitignore()
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "c8 node --test"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Resolve all your $refs",
   "main": "ref-resolver.js",
   "scripts": {
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
     "test": "c8 node --test"
   },
   "engines": {
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/Eomm/json-schema-resolver#readme",
   "devDependencies": {
     "c8": "^10.1.3",
-    "standard": "^17.0.0"
+    "eslint": "^9.18.0",
+    "neostandard": "^0.12.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "rfdc": "^1.1.4",
-    "uri-js": "^4.2.2"
+    "fast-uri": "^3.0.5",
+    "rfdc": "^1.1.4"
   },
   "keywords": [
     "json",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "tap test/**/*.test.js"
+    "test": "c8 node --test"
   },
   "engines": {
     "node": ">=10"
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/Eomm/json-schema-resolver#readme",
   "devDependencies": {
-    "standard": "^17.0.0",
-    "tap": "^16.3.0"
+    "c8": "^10.1.3",
+    "standard": "^17.0.0"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/ref-resolver.js
+++ b/ref-resolver.js
@@ -103,7 +103,7 @@ function jsonSchemaResolver (options) {
     if (rootSchema.$id) {
       rootSchema.$id = baseUri // fix the schema $id value
     }
-    rootSchema[kIgnore] = true
+    Object.defineProperty(rootSchema, kIgnore, { value: true, enumerable: false })
 
     mapIds(ee, appUri, rootSchema)
     debug('Processed root schema')
@@ -118,7 +118,7 @@ function jsonSchemaResolver (options) {
         debug('External $ref %s not provided with baseUri %s', ref, baseUri)
         return
       }
-      evaluatedJson[kConsumed] = true
+      Object.defineProperty(evaluatedJson, kConsumed, { value: true, enumerable: false })
       json.$ref = `#/definitions/${evaluatedJson[kRefToDef]}${refUri.fragment || ''}`
     })
 
@@ -146,7 +146,8 @@ function jsonSchemaResolver (options) {
     const id = URI.serialize(baseUri) + rel
     if (!allIds.has(id)) {
       debug('Collected $id %s', id)
-      json[kRefToDef] = buildLocalReference(json, baseUri, fragment, rolling++)
+      const value = buildLocalReference(json, baseUri, fragment, rolling++)
+      Object.defineProperty(json, kRefToDef, { value, enumerable: false })
       allIds.set(id, json)
     } else {
       debug('WARN duplicated id %s .. IGNORED - ', id)

--- a/ref-resolver.js
+++ b/ref-resolver.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const URI = require('uri-js')
+const URI = require('fast-uri')
 const cloner = require('rfdc')({ proto: true, circles: false })
 const { EventEmitter } = require('events')
 const debug = require('debug')('json-schema-resolver')

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 
 const RefResolver = require('../ref-resolver')
 
@@ -32,7 +32,7 @@ test('readme example', t => {
 
   const singleSchema = ref.resolve(inputSchema, { externalSchemas: [addresSchema] })
 
-  t.same(singleSchema, {
+  t.assert.deepStrictEqual(singleSchema, {
     $id: 'http://example.com/SimplePerson',
     type: 'object',
     properties: {
@@ -100,7 +100,7 @@ test('readme example #2', t => {
   // to get the definition you need only to call:
   const sharedDefinitions = ref.definitions()
 
-  t.same(sharedDefinitions, {
+  t.assert.deepStrictEqual(sharedDefinitions, {
     definitions: {
       'def-0': {
         $id: 'relativeAddress',
@@ -117,7 +117,7 @@ test('readme example #2', t => {
     }
   })
 
-  t.same(singleSchema, {
+  t.assert.deepStrictEqual(singleSchema, {
     $id: 'my-application.org',
     type: 'object',
     properties: {

--- a/test/ref-as-is.test.js
+++ b/test/ref-as-is.test.js
@@ -1,6 +1,6 @@
 
-const { test } = require('tap')
-const URI = require('uri-js')
+const { test } = require('node:test')
+const URI = require('fast-uri')
 const RefResolver = require('../ref-resolver')
 
 test('resolving schema within the $id', t => {
@@ -33,8 +33,8 @@ test('resolving schema within the $id', t => {
   const resolver = RefResolver(opts)
   const out = resolver.resolve(schema)
   const externalDef = resolver.definitions()
-  t.equal(out.properties.greetings.$ref, '#/definitions/greetings')
-  t.same(externalDef.definitions.greetings, opts.externalSchemas[0])
+  t.assert.strictEqual(out.properties.greetings.$ref, '#/definitions/greetings')
+  t.assert.deepStrictEqual(externalDef.definitions.greetings, opts.externalSchemas[0])
 })
 
 test('resolving schema within the $id case #2', t => {
@@ -66,11 +66,11 @@ test('resolving schema within the $id case #2', t => {
 
   const resolver = RefResolver(opts)
   const out = resolver.resolve(schema)
-  t.equal(out.properties.hello.$ref, '#/definitions/urn%3Aschema%3Abase/definitions/hello')
+  t.assert.strictEqual(out.properties.hello.$ref, '#/definitions/urn%3Aschema%3Abase/definitions/hello')
 
   const externalDef = resolver.definitions()
-  t.ok(externalDef.definitions['urn%3Aschema%3Abase'], 'buildLocalReference result')
-  t.ok(externalDef.definitions['urn%3Aschema%3Aref'], 'buildLocalReference result')
+  t.assert.ok(externalDef.definitions['urn%3Aschema%3Abase'], 'buildLocalReference result')
+  t.assert.ok(externalDef.definitions['urn%3Aschema%3Aref'], 'buildLocalReference result')
 })
 
 test('resolving schema within the $id relative', t => {
@@ -99,7 +99,7 @@ test('resolving schema within the $id relative', t => {
       }
     ],
     buildLocalReference (json, baseUri, fragment, i) {
-      t.equal(URI.serialize(baseUri), baseUriCheck.shift())
+      t.assert.strictEqual(URI.serialize(baseUri), baseUriCheck.shift())
       return escape(json.$id)
     }
   }
@@ -111,6 +111,6 @@ test('resolving schema within the $id relative', t => {
 
   const resolver = RefResolver(opts)
   const out = resolver.resolve(schema)
-  t.equal(out.properties.user.$ref, '#/definitions/http%3A//hello.absolute/user.json/definitions/name')
-  t.equal(out.properties.address.$ref, '#/definitions/adr/definitions/street')
+  t.assert.strictEqual(out.properties.user.$ref, '#/definitions/http%3A//hello.absolute/user.json/definitions/name')
+  t.assert.strictEqual(out.properties.address.$ref, '#/definitions/adr/definitions/street')
 })

--- a/test/ref-as-is.test.js
+++ b/test/ref-as-is.test.js
@@ -1,4 +1,3 @@
-
 const { test } = require('node:test')
 const URI = require('fast-uri')
 const RefResolver = require('../ref-resolver')

--- a/test/ref-fragment.test.js
+++ b/test/ref-fragment.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 
 const RefResolver = require('../ref-resolver')
 
@@ -30,7 +30,7 @@ test('Preserve $ref fragment', t => {
     }
   }, opts)
 
-  t.same(out, {
+  t.assert.deepStrictEqual(out, {
     $id: 'my-schema',
     type: 'object',
     properties: {

--- a/test/ref-local.test.js
+++ b/test/ref-local.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 
 const RefResolver = require('../ref-resolver')
 
@@ -45,7 +45,7 @@ test('Resolve absolute refs in schema', t => {
     $ref: 'ObjectC#'
   }, opts)
 
-  t.same(out, {
+  t.assert.deepStrictEqual(out, {
     $ref: '#/definitions/def-1',
     definitions: {
       'def-0': {
@@ -110,7 +110,7 @@ test('Resolve relative refs in schema', t => {
     $ref: 'ObjectA#/properties/relativeExample'
   }, opts)
 
-  t.same(out, {
+  t.assert.deepStrictEqual(out, {
     $ref: '#/definitions/def-0/properties/relativeExample',
     definitions: {
       'def-0': {

--- a/test/ref-resolver.test.js
+++ b/test/ref-resolver.test.js
@@ -13,8 +13,8 @@ const save = (out) => require('fs').writeFileSync(`./out-${Date.now()}.json`, JS
 
 test('wrong params', t => {
   t.plan(2)
-  t.throws(() => RefResolver({ target: 'draft-1000' }))
-  t.throws(() => RefResolver({ externalSchemas: [] }), 'need application uri')
+  t.assert.throws(() => RefResolver({ target: 'draft-1000' }))
+  t.assert.throws(() => RefResolver({ externalSchemas: [] }), 'need application uri')
 })
 
 test('$ref to root', t => {

--- a/test/ref-resolver.test.js
+++ b/test/ref-resolver.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const clone = require('rfdc')({ proto: true, circles: false })
 
 const RefResolver = require('../ref-resolver')
@@ -31,8 +31,8 @@ test('$ref to root', t => {
 
   const originalSchema = clone(schema)
   const out = resolver.resolve(schema, opts)
-  t.same(schema, originalSchema, 'the param schema should not be changed')
-  t.equal(schema, out, 'the output schema is the same (LINK) of the input one')
+  t.assert.deepStrictEqual(schema, originalSchema, 'the param schema should not be changed')
+  t.assert.strictEqual(schema, out, 'the output schema is the same (LINK) of the input one')
 })
 
 test('$ref to an external schema', t => {
@@ -48,9 +48,9 @@ test('$ref to an external schema', t => {
   const resolver = RefResolver()
 
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input - modified')
-  t.ok(out.definitions, 'definitions has been added')
-  t.same(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input - modified')
+  t.assert.ok(out.definitions, 'definitions has been added')
+  t.assert.deepStrictEqual(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
 })
 
 test('$ref to an external schema without changes', t => {
@@ -67,10 +67,10 @@ test('$ref to an external schema without changes', t => {
 
   const originalSchema = clone(schema)
   const out = resolver.resolve(schema, opts)
-  t.same(schema, originalSchema, 'the input is unchanged')
-  t.notMatch(schema, out, 'the input is unchanged')
-  t.ok(out.definitions, 'definitions has been added')
-  t.same(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
+  t.assert.deepStrictEqual(schema, originalSchema, 'the input is unchanged')
+  t.assert.notDeepStrictEqual(schema, out, 'the input is unchanged')
+  t.assert.ok(out.definitions, 'definitions has been added')
+  t.assert.deepStrictEqual(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
 })
 
 test('$ref circular', t => {
@@ -89,9 +89,9 @@ test('$ref circular', t => {
 
   const resolver = RefResolver()
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input modified')
-  t.ok(out.definitions, 'definitions has been added')
-  t.same(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input modified')
+  t.assert.ok(out.definitions, 'definitions has been added')
+  t.assert.deepStrictEqual(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
 })
 
 test('$ref circular', t => {
@@ -110,9 +110,9 @@ test('$ref circular', t => {
 
   const resolver = RefResolver()
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input modified')
-  t.ok(out.definitions, 'definitions has been added')
-  t.same(Object.values(out.definitions), [opts.externalSchemas[1]], 'only used schema are added')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input modified')
+  t.assert.ok(out.definitions, 'definitions has been added')
+  t.assert.deepStrictEqual(Object.values(out.definitions), [opts.externalSchemas[1]], 'only used schema are added')
 })
 
 test('$ref local ids', { skip: true }, t => {
@@ -128,9 +128,9 @@ test('$ref local ids', { skip: true }, t => {
 
   const resolver = RefResolver()
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input modified')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input modified')
   // TODO build a graph to track is an external schema is referenced by the root
-  t.equal(Object.values(out.definitions).length, 1, 'no external schema added')
+  t.assert.strictEqual(Object.values(out.definitions).length, 1, 'no external schema added')
 })
 
 test('skip duplicated ids', t => {
@@ -145,8 +145,8 @@ test('skip duplicated ids', t => {
 
   const resolver = RefResolver()
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input modified')
-  t.equal(Object.values(out.definitions).length, 1, 'no external schema added')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input modified')
+  t.assert.strictEqual(Object.values(out.definitions).length, 1, 'no external schema added')
 })
 
 test('dont resolve external schema missing', t => {
@@ -155,7 +155,7 @@ test('dont resolve external schema missing', t => {
 
   const resolver = RefResolver({ clone: true })
   const out = resolver.resolve(schema)
-  t.same(schema, out, 'the output is the same input not modified')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input not modified')
 })
 
 test('dont resolve external schema missing #2', t => {
@@ -164,7 +164,7 @@ test('dont resolve external schema missing #2', t => {
 
   const resolver = RefResolver({ clone: true })
   const out = resolver.resolve(schema)
-  t.same(schema, out, 'the output is the same input not modified')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input not modified')
 })
 
 test('missing id in root schema', t => {
@@ -182,9 +182,9 @@ test('missing id in root schema', t => {
 
   const resolver = RefResolver()
   const out = resolver.resolve(schema, opts)
-  t.same(schema, out, 'the output is the same input modified')
-  t.ok(out.definitions, 'definitions has been added')
-  t.same(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
+  t.assert.deepStrictEqual(schema, out, 'the output is the same input modified')
+  t.assert.ok(out.definitions, 'definitions has been added')
+  t.assert.deepStrictEqual(Object.values(out.definitions), opts.externalSchemas, 'external schema has been added to definitions')
 })
 
 test('absolute $ref', t => {
@@ -214,8 +214,8 @@ test('absolute $ref', t => {
   const resolver = RefResolver({ clone: true, applicationUri: 'todo.com', externalSchemas })
   const out = resolver.resolve(schema)
 
-  t.not(out.$ref, 'http://example.com/#/definitions/idParam')
-  t.same(resolver.definitions(), {
+  t.assert.notEqual(out.$ref, 'http://example.com/#/definitions/idParam')
+  t.assert.deepStrictEqual(resolver.definitions(), {
     definitions: {
       'def-0': absSchemaId
     }
@@ -241,6 +241,6 @@ test('absolute $ref #2', t => {
 
   const resolver = RefResolver({ clone: true })
   const out = resolver.resolve(schema, { externalSchemas })
-  t.equal(out.properties.address.$ref, '#/definitions/def-0')
-  t.equal(out.properties.houses.items.$ref, '#/definitions/def-0')
+  t.assert.strictEqual(out.properties.address.$ref, '#/definitions/def-0')
+  t.assert.strictEqual(out.properties.houses.items.$ref, '#/definitions/def-0')
 })

--- a/test/ref-root.test.js
+++ b/test/ref-root.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const clone = require('rfdc')({ proto: true, circles: false })
 
 const RefResolver = require('../ref-resolver')
@@ -25,11 +25,11 @@ test('application uri priority', t => {
   const resolver = RefResolver(opts)
 
   resolver.resolve(schema)
-  t.not(schema.$id, 'http://example.com/SimplePerson')
-  t.equal(schema.$id, 'one-single-uri.to')
+  t.assert.notEqual(schema.$id, 'http://example.com/SimplePerson')
+  t.assert.strictEqual(schema.$id, 'one-single-uri.to')
 
   const externalDef = resolver.definitions()
-  t.same(externalDef.definitions, {})
+  t.assert.deepStrictEqual(externalDef.definitions, {})
 })
 
 test('multiple resolve over same externals', t => {
@@ -50,15 +50,15 @@ test('multiple resolve over same externals', t => {
   const resolver = RefResolver(opts)
 
   const out1 = resolver.resolve(schema1)
-  t.notMatch(schema1, originalSchema1, 'the refs has been changed')
-  t.same(out1, schema1)
-  t.notOk(schema1.definitions, 'definition has not been added')
+  t.assert.notDeepStrictEqual(schema1, originalSchema1, 'the refs has been changed')
+  t.assert.deepStrictEqual(out1, schema1)
+  t.assert.ok(!schema1.definitions, 'definition has not been added')
 
   const out2 = resolver.resolve(schema2)
-  t.notMatch(schema2, originalSchema2, 'the refs has been changed')
-  t.same(out2, schema2)
-  t.notOk(schema2.definitions, 'definition has not been added')
+  t.assert.notDeepStrictEqual(schema2, originalSchema2, 'the refs has been changed')
+  t.assert.deepStrictEqual(out2, schema2)
+  t.assert.ok(!schema2.definitions, 'definition has not been added')
 
   const externalDef = resolver.definitions()
-  t.same(externalDef.definitions['def-0'], factory('relativeId-noRef'))
+  t.assert.deepStrictEqual(externalDef.definitions['def-0'], factory('relativeId-noRef'))
 })


### PR DESCRIPTION
Fixes https://github.com/Eomm/json-schema-resolver/issues/19

- Drop old nodejs
- Moved from uri-js to fast-uri
- (chore): drop tap
- (chore): new linter